### PR TITLE
Select correct repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,17 @@
         "command": "codeHistories.checkAndCommit",
         "title": "Code Histories commit",
         "icon": "$(run-all)"
+      },
+      {
+        "command": "codeHistories.selectGitRepo",
+        "title": "Code Histories: Select git repo"
+      }
+    ],
+    "keybindings":[
+      {
+        "command": "codeHistories.selectGitRepo",
+        "key": "Ctrl+Shift+G",
+        "mac": "Cmd+Shift+G"
       }
     ],
     "menus": {

--- a/src/extension.js
+++ b/src/extension.js
@@ -33,7 +33,8 @@ function activate(context) {
 	simpleGit().clean(simpleGit.CleanOptions.FORCE);
 	var currentDir = vscode.workspace.workspaceFolders[0].uri.fsPath;
 	tracker = new gitTracker(currentDir);
-	tracker.isGitInitialized();
+	tracker.presentGitRepos();
+	// tracker.isGitInitialized();
 
 	// get user and hostname for regex matching
 	var user = os.userInfo().username;
@@ -466,8 +467,18 @@ function activate(context) {
 		});
 	});
 
+	let selectGitRepo = vscode.commands.registerCommand('codeHistories.selectGitRepo', function () {
+		// if codeHistories is not activated, activate it
+		if(!tracker){
+			vscode.window.showErrorMessage('Code histories is not activated!');
+		} else {
+			tracker.presentGitRepos();
+		}
+	});
+
 	context.subscriptions.push(disposable);
 	context.subscriptions.push(executeCode);
+	context.subscriptions.push(selectGitRepo);
 }
 
 function countOccurrences(string, word) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -33,8 +33,7 @@ function activate(context) {
 	simpleGit().clean(simpleGit.CleanOptions.FORCE);
 	var currentDir = vscode.workspace.workspaceFolders[0].uri.fsPath;
 	tracker = new gitTracker(currentDir);
-	tracker.presentGitRepos();
-	// tracker.isGitInitialized();
+	tracker.createGitFolders();
 
 	// get user and hostname for regex matching
 	var user = os.userInfo().username;
@@ -468,7 +467,6 @@ function activate(context) {
 	});
 
 	let selectGitRepo = vscode.commands.registerCommand('codeHistories.selectGitRepo', function () {
-		// if codeHistories is not activated, activate it
 		if(!tracker){
 			vscode.window.showErrorMessage('Code histories is not activated!');
 		} else {

--- a/src/git-tracker.js
+++ b/src/git-tracker.js
@@ -1,6 +1,7 @@
 const vscode = require('vscode');
 const simpleGit = require('simple-git');
 const fs = require('fs');
+const cp = require('child_process');
 
 module.exports = class gitTracker {
     constructor(currentDir) {
@@ -21,6 +22,36 @@ module.exports = class gitTracker {
 
     isGitInitialized() {
         this.git = simpleGit(this._currentDir);
+
+        if(process.platform === 'win32') {
+            var gitReposInCurrentDir = cp.execSync('Get-ChildItem . -Attributes Directory+Hidden -ErrorAction SilentlyContinue -Filter ".git" -Recurse | % { Write-Host $_.FullName }', {cwd: this._currentDir, shell: "PowerShell"});
+            // console.log(gitRepoInCurrentDir.toString());
+            // get individual lines of output
+            var gitRepos = gitReposInCurrentDir.toString().split('\n');
+            // console.log(gitRepos);
+
+            // eliminate empty lines
+            gitRepos = gitRepos.filter(function (el) {
+                return el != "";
+            });
+
+            // remove .git from the end of each line
+            var gitReposFiltered = gitRepos.map(function (el) {
+                return el.substring(0, el.length - 5);
+            });
+
+            console.log(gitReposFiltered);
+
+        }
+
+        // const wholeRepoStatus = this.git.status();
+        // const subDirStatusUsingOptArray = this.git.status(['--', 'sub-dir']);
+        // const subDirStatusUsingOptObject = this.git.status({ '--': null, 'sub-dir': null });
+
+        // console.log('wholeRepoStatus: ', wholeRepoStatus);
+        // console.log('subDirStatusUsingOptArray: ', subDirStatusUsingOptArray);
+        // console.log('subDirStatusUsingOptObject: ', subDirStatusUsingOptObject);
+
         return this.git.checkIsRepo()
             .then(isRepo => !isRepo && this.initializeGit(this.git))
             .then(() => this.git.fetch());

--- a/src/git-tracker.js
+++ b/src/git-tracker.js
@@ -39,7 +39,7 @@ module.exports = class gitTracker {
         if(process.platform === 'win32') {
             gitReposInCurrentDir = cp.execSync('Get-ChildItem . -Attributes Directory,Hidden -ErrorAction SilentlyContinue -Filter *.git -Recurse | % { Write-Host $_.FullName }', {cwd: this._initialWorkspaceDir, shell: "PowerShell"});
         }
-        else if(process.platform === 'darwin') {
+        else if(process.platform === 'darwin' || process.platform === 'linux') {
             gitReposInCurrentDir = cp.execSync('find ~+ -type d -name "*.git"', {cwd: this._initialWorkspaceDir, shell: "bash"});
         }
 
@@ -50,6 +50,11 @@ module.exports = class gitTracker {
         // eliminate empty lines
         gitRepos = gitRepos.filter(function (el) {
             return el != "";
+        });
+
+        // make first letter of each line lowercase
+        gitRepos = gitRepos.map(function (el) {
+            return el.charAt(0).toLowerCase() + el.slice(1);
         });
 
         console.log(gitRepos);
@@ -63,8 +68,10 @@ module.exports = class gitTracker {
 
             if(this.isUsingCodeHistoriesGit){
                 // if current directory is in gitRepos, add it to the top of the list
-                if(gitRepos.includes(this._currentDir + '\\codeHistories.git') || gitRepos.includes(this._currentDir + '/codeHistories.git')) {
+                if(gitRepos.includes(this._currentDir + '\\codeHistories.git')){
                     items.push({ label: this._currentDir + '\\codeHistories.git', description: "Current repo" });
+                } else if(gitRepos.includes(this._currentDir + '/codeHistories.git')){
+                    items.push({ label: this._currentDir + '/codeHistories.git', description: "Current repo" });
                 }
                 // add all other git repos to the list
                 for(var i = 0; i < gitRepos.length; i++) {
@@ -73,8 +80,10 @@ module.exports = class gitTracker {
                     }
                 }
             } else {
-                if(gitRepos.includes(this._currentDir + '\\.git') || gitRepos.includes(this._currentDir + '/.git')) {
+                if(gitRepos.includes(this._currentDir + '\\.git')){
                     items.push({ label: this._currentDir + '\\.git', description: "Current repo" });
+                } else if(gitRepos.includes(this._currentDir + '/.git')){
+                    items.push({ label: this._currentDir + '/.git', description: "Current repo" });
                 }
                 for(var i = 0; i < gitRepos.length; i++) {
                     if(gitRepos[i] != this._currentDir + '\\.git' && gitRepos[i] != this._currentDir + '/.git') {


### PR DESCRIPTION
The intention here is to have a git repo solely for codeHistories commits which would not interfere with commonly known .git repo (that might contain more meaningful, containing larger changes commits).

When starting up codeHistories extension, codeHistories.git will be set as default. The user can switch back and forth between .git and codeHistories.git using Ctrl + Shift + G (or CMD + Shift + G on Mac) or searching for Code Histories: Select git repo (from VS Code View tab -> command palette option).