### PR TITLE
Keyword cmd capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ https://user-images.githubusercontent.com/44308446/158084110-06305b2c-af13-4664-
 1.  Clone this repository.
 2.  Download the Insiders version of VSCode: https://code.visualstudio.com/insiders/
 3.  Open VSCode. You can determine whether you’ve gotten Insiders based on the icon color, which should be jade green for Insiders (rather than blue).
-4.  Install the Code Runner Extension. You should be able to search for it from the extensions tab on the left hand side of the screen (looks like little blocks).
-5.  Open the code histories repository folder in VSCode.
-6.  From the main directory of the code histories repository, run ```npm i``` to install all dependencies.
-7.  Back in VSCode, press f5 (fn + F5 for Mac) to enter debug mode. This will open a new VScode window which has "[Extension Development Host]" in its name. This is where you should set up the code that you want to be tracked.
-8.  Open the repository or folder that you want to work in using VSCode.
-9.  CTRL-SHIFT-P should start the extension (CMD-SHIFT-P for Mac). That will bring up a menu of options. Look for and choose Code Histories. Note: When this runs, it should automatically create the settings that are needed for the extension. But, if that fails to happen (which would manifest as an error on CTRL-SHIFT-P) you can do the following:
+4.  Open the code histories repository folder in VSCode.
+5.  From the main directory of the code histories repository, run ```npm i``` to install all dependencies.
+6.  Back in VSCode, press f5 (fn + F5 for Mac) to enter debug mode. This will open a new VScode window which has "[Extension Development Host]" in its name. This is where you should set up the code that you want to be tracked.
+7.  Open the repository or folder that you want to work in using VSCode.
+8.  CTRL-SHIFT-P should start the extension (CMD-SHIFT-P for Mac). That will bring up a menu of options. Look for and choose Code Histories. Note: When this runs, it should automatically create the settings that are needed for the extension. But, if that fails to happen (which would manifest as an error on CTRL-SHIFT-P) you can do the following:
     -   Open the directory in a file browser
 
     -   Make .vscode directory
@@ -44,11 +43,13 @@ https://user-images.githubusercontent.com/44308446/158084110-06305b2c-af13-4664-
         }
         ```
 
-10.  You should see a “Code Histories activated.” message on the bottom right of the screen when it is running.
+9.  You should see a “Code Histories activated.” message on the bottom right of the screen when it is running.
+
+10. Press on the multi-play button (which says “Code Histories commit” if you hover over it) the first time to enter Code Histories terminal and load in .bash_profile.
 
 ## Important notes
 
-1. When the extension starts, it will create .bash_profile in your root folder (~) and add this information to it:
+1. When the extension starts, it will automatically create .bash_profile in your root folder (~) and add the following information:
     
     ```
     codehistories() {
@@ -62,14 +63,12 @@ https://user-images.githubusercontent.com/44308446/158084110-06305b2c-af13-4664-
     }
     ```
     This is to make sure that when you run ```codehistories <cmd> [args]```, the bash terminal can understand and capture the execution's output. You need to always run your code with ```codehistories``` as prefix since it is an important keyword for the tool to capture the code state and output.
-    
-2. Press on the multi-play button (which says “Code Histories commit” if you hover over it) the first time to load in the bash_profile.
 
-3. In case you don't want to type out full execution command every time, you use Ctrl + Shift + C (or CMD + Shift + C on Mac) to update the command for the subsequent executions. Then you can press the multi-play button to run the updated execution. For e.g. if you want to run an http server, you set the command to ```python -m http.server 8080```. Note that this command will be updated for all future executions until you change it again.
+2. In case you don't want to type out full execution command every time, you use Ctrl + Shift + C (or CMD + Shift + C on Mac) to update the command for the subsequent executions. Then you can press the multi-play button to run the updated execution. For e.g. if you want to run an http server, you set the command to ```python -m http.server 8080```. Note that this command will be updated for all future executions until you change it again.
 
-4. Please don’t make changes while the code is running, as these may not be captured correctly. Also, if you do not want to commit changes because an execution was detected incorrectly, there is a confirmation box on the lower right of the screen that will appear after the codes were committed so you can undo and go back to the previous commit. In the case where the box has already disappeared, you can do ```git reset HEAD~1``` in the terminal to revert back to the previous correct commit.
+3. Please don’t make changes while the code is running, as these may not be captured correctly. Also, if you do not want to commit changes because an execution was detected incorrectly, there is a confirmation box on the lower right of the screen that will appear after the codes were committed so you can undo and go back to the previous commit. In the case where the box has already disappeared, you can do ```git reset HEAD~1``` in the terminal to revert back to the previous correct commit.
 
-5. When starting up codeHistories extension, codeHistories.git will be created and set as default. The intention here is to have a git repo solely for codeHistories commits which would not interfere with the commonly known .git repo (that might contain more meaningful, containing larger changes commits, especially if user starts out with repos cloned online).The user can switch back and forth between .git and codeHistories.git using Ctrl + Shift + G (or CMD + Shift + G on Mac) or searching for Code Histories: Select git repo (from VS Code View tab -> Command Palette.. option).
+4. When starting up codeHistories extension, codeHistories.git will be created and set as default. The intention here is to have a git repo solely for codeHistories commits which would not interfere with the commonly known .git repo (that might contain more meaningful, containing larger changes commits, especially if user starts out with repos cloned online).The user can switch back and forth between .git and codeHistories.git using Ctrl + Shift + G (or CMD + Shift + G on Mac) or searching for Code Histories: Select git repo (from VS Code View tab -> Command Palette.. option).
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ https://user-images.githubusercontent.com/44308446/158084110-06305b2c-af13-4664-
 * VS Code Insiders version (https://code.visualstudio.com/insiders/) to use their proposed API
 * Node JS + simple-git (https://github.com/steveukx/git-js) to incorporate git in the output tracking process
 * Git Bash installed for Windows user
-* Code Runner extension (https://github.com/formulahendry/vscode-code-runner) to utilize multiple language execution support
-* Default Python extension for VS Code (https://github.com/Microsoft/vscode-python) is also an option for Python file execution
 
 ## Extension Setup
 
@@ -22,7 +20,7 @@ https://user-images.githubusercontent.com/44308446/158084110-06305b2c-af13-4664-
 4.  Install the Code Runner Extension. You should be able to search for it from the extensions tab on the left hand side of the screen (looks like little blocks).
 5.  Open the code histories repository folder in VSCode.
 6.  From the main directory of the code histories repository, run ```npm i``` to install all dependencies.
-7.  Back in VSCode, press f5 to enter debug mode. This will open a new VScode window which has "[Extension Development Host]" in its name. This is where you should set up the code that you want to be tracked.
+7.  Back in VSCode, press f5 (fn + F5 for Mac) to enter debug mode. This will open a new VScode window which has "[Extension Development Host]" in its name. This is where you should set up the code that you want to be tracked.
 8.  Open the repository or folder that you want to work in using VSCode.
 9.  CTRL-SHIFT-P should start the extension (CMD-SHIFT-P for Mac). That will bring up a menu of options. Look for and choose Code Histories. Note: When this runs, it should automatically create the settings that are needed for the extension. But, if that fails to happen (which would manifest as an error on CTRL-SHIFT-P) you can do the following:
     -   Open the directory in a file browser
@@ -41,23 +39,37 @@ https://user-images.githubusercontent.com/44308446/158084110-06305b2c-af13-4664-
             "terminal.integrated.defaultProfile.windows": "Git Bash",
             "terminal.integrated.defaultProfile.osx": "bash",
             "terminal.integrated.defaultProfile.linux": "bash",
-            "code-runner.runInTerminal": true,
-            "code-runner.ignoreSelection": true,
-            "code-runner.clearPreviousOutput": false,
             "terminal.integrated.shellIntegration.enabled": false,
-            "python.terminal.activateEnvironment": false,
-            "code-runner.executorMap": {
-                "html": "python -m http.server 8080 --directory \"$workspaceRoot\"",
-            }
+            "python.terminal.activateEnvironment": false
         }
         ```
 
 10.  You should see a “Code Histories activated.” message on the bottom right of the screen when it is running.
-11. Press the multi-play button (which says “Code Histories commit” if you hover over it) to run your project. If it’s a web project using a localhost server, start from an html page. Then you’ll need to open localhost:8080 in a browser. 
-You can change to a different port by updating the number in settings.json.
-You can refer to https://github.com/formulahendry/vscode-code-runner for more execution configurations and update the settings.json. For e.g. if you are using Python <3.7 there would be no ```--directory \"$workspaceRoot\""```
-12. When you are done testing, press CRTL-C in the vscode console to stop the execution. This will trigger capturing the current code. (Note: please don’t make changes while the code is running, as these may not be captured correctly. Also, if you do not want to commit changes because an execution was detected incorrectly, there is a confirmation box on the lower right of the screen that will appear when you press CTRL-C and you can cancel the commit. In the case where the message has already disappeared, you can do ```git reset HEAD~1``` in the terminal to revert back to the previous correct commit.)
-13. When starting up codeHistories extension, codeHistories.git will be created and set as default. The intention here is to have a git repo solely for codeHistories commits which would not interfere with the commonly known .git repo (that might contain more meaningful, containing larger changes commits, especially if user starts out with repos cloned online).The user can switch back and forth between .git and codeHistories.git using Ctrl + Shift + G (or CMD + Shift + G on Mac) or searching for Code Histories: Select git repo (from VS Code View tab -> Command Palette.. option).
+
+## Important notes
+
+1. When the extension starts, it will create .bash_profile in your root folder (~) and add this information to it:
+    
+    ```
+    codehistories() {
+        if [ "$#" -eq 0 ]; then
+            echo "Usage: codehistories <command> [args]"
+            return
+        fi
+        cmd="$1"
+        shift
+        eval "$cmd" "$@"
+    }
+    ```
+    This is to make sure that when you run ```codehistories <cmd> [args]```, the bash terminal can understand and capture the execution's output. You need to always run your code with ```codehistories``` as prefix since it is an important keyword for the tool to capture the code state and output.
+    
+2. Press on the multi-play button (which says “Code Histories commit” if you hover over it) the first time to load in the bash_profile.
+
+3. In case you don't want to type out full execution command every time, you use Ctrl + Shift + C (or CMD + Shift + C on Mac) to update the command for the subsequent executions. Then you can press the multi-play button to run the updated execution. For e.g. if you want to run an http server, you set the command to ```python -m http.server 8080```. Note that this command will be updated for all future executions until you change it again.
+
+4. Please don’t make changes while the code is running, as these may not be captured correctly. Also, if you do not want to commit changes because an execution was detected incorrectly, there is a confirmation box on the lower right of the screen that will appear after the codes were committed so you can undo and go back to the previous commit. In the case where the box has already disappeared, you can do ```git reset HEAD~1``` in the terminal to revert back to the previous correct commit.
+
+5. When starting up codeHistories extension, codeHistories.git will be created and set as default. The intention here is to have a git repo solely for codeHistories commits which would not interfere with the commonly known .git repo (that might contain more meaningful, containing larger changes commits, especially if user starts out with repos cloned online).The user can switch back and forth between .git and codeHistories.git using Ctrl + Shift + G (or CMD + Shift + G on Mac) or searching for Code Histories: Select git repo (from VS Code View tab -> Command Palette.. option).
 
 ## Release Notes
 
@@ -76,6 +88,10 @@ Avoid resizing VS Code window when the code is executing as that might impact th
 ### V2.x
 
 Added support for Linux. A custom "Code Histories commit" button is added to enforce correct output capture behavior (i.e. only when the user clicks on this button). For directly typed executions in the terminal, there has not been a better solution than asking the user to revert a commit if it was triggered wrong. Comment out ```if(checkThenCommit)``` statement in extension.js to enable direct terminal execution capture.
+
+### V3
+
+Removed the need for code-runner extension. Using ```codehistories``` as a prefix in commands serves as a important keyword trigger for the tool to capture the code state and output. Currently safe to interact directly with the "Code Histories" terminal. Similar to code-runner, the user can use a run button to execute the code, but they would need to update the command using Ctrl + Shift + C (or CMD + Shift + C on Mac) before pressing the run button (Code Histories commit). The added pseudogit feature allows the user to keep various small commits related to codeHistories separate from .git.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A VS Code extension that aims to capture the information needed to generate usable code histories (capturing code state and output). This work remains a prototype for research purposes.
 
-## Demo
+## Setup demo
 
-https://user-images.githubusercontent.com/44308446/158084110-06305b2c-af13-4664-8041-ec044a58efff.mp4
+https://user-images.githubusercontent.com/44308446/219846324-bd156916-f2e0-4cd0-92b9-0481ced5a7f5.mp4
 
 ## Requirements
 
@@ -69,6 +69,8 @@ https://user-images.githubusercontent.com/44308446/158084110-06305b2c-af13-4664-
 3. Please don’t make changes while the code is running, as these may not be captured correctly. Also, if you do not want to commit changes because an execution was detected incorrectly, there is a confirmation box on the lower right of the screen that will appear after the codes were committed so you can undo and go back to the previous commit. In the case where the box has already disappeared, you can do ```git reset HEAD~1``` in the terminal to revert back to the previous correct commit.
 
 4. When starting up codeHistories extension, codeHistories.git will be created and set as default. The intention here is to have a git repo solely for codeHistories commits which would not interfere with the commonly known .git repo (that might contain more meaningful, containing larger changes commits, especially if user starts out with repos cloned online).The user can switch back and forth between .git and codeHistories.git using Ctrl + Shift + G (or CMD + Shift + G on Mac) or searching for Code Histories: Select git repo (from VS Code View tab -> Command Palette.. option).
+
+5. To use git commands that are related to codeHistories.git, you need to add ```--git-dir=codeHistories.git --work-tree=.``` between ```git``` and the command. For e.g. ```git --git-dir=codeHistories.git --work-tree=. log --pretty=oneline``` to view the codeHistories commits. Occasionally checking this would be a good idea since the files color change only corresponds to normal .git repo.
 
 ## Release Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1614,9 +1614,9 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
-      "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.1.tgz",
+      "integrity": "sha512-xzRxMKiy1zEYeHGXgAzvuXffDS0xgsq07Oi4LWEEcVH29vLpcZ2tyQRWyK0NLLlCVaKysZeem5tC1qHEOxsKwA==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -3125,9 +3125,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
-      "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.1.tgz",
+      "integrity": "sha512-xzRxMKiy1zEYeHGXgAzvuXffDS0xgsq07Oi4LWEEcVH29vLpcZ2tyQRWyK0NLLlCVaKysZeem5tC1qHEOxsKwA==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
       {
         "command": "codeHistories.selectGitRepo",
         "title": "Code Histories: Select git repo"
+      },
+      {
+        "command": "codeHistories.setNewCmd",
+        "title": "Code Histories: Set new command"
       }
     ],
     "keybindings":[
@@ -38,6 +42,11 @@
         "command": "codeHistories.selectGitRepo",
         "key": "Ctrl+Shift+G",
         "mac": "Cmd+Shift+G"
+      },
+      {
+        "command": "codeHistories.setNewCmd",
+        "key": "Ctrl+Shift+C",
+        "mac": "Cmd+Shift+C"
       }
     ],
     "menus": {

--- a/src/extension.js
+++ b/src/extension.js
@@ -106,7 +106,11 @@ function activate(context) {
 							var matched = terminalData.match(win_regex_dir);
 							console.log('matched: ', matched);
 
-							allTerminalsDirCount[pid] += matched.length;
+							//if matched.length is a number
+							if(matched.length){
+								// add length of matched array to counterMatchedDir
+								allTerminalsDirCount[pid] += matched.length;
+							}
 						}
 
 						// iter += 1;
@@ -115,7 +119,7 @@ function activate(context) {
 
 						// allTerminalsData[pid] = globalStr of the terminal instance with pid
 						allTerminalsData[pid] += terminalData;
-						console.log('allTerminalsData: ', allTerminalsData[pid]);
+						// console.log('allTerminalsData: ', allTerminalsData[pid]);
 
 						// if(checkThenCommit){
 							console.log('There are %s matched regex dir for pid %s', allTerminalsDirCount[pid], pid);
@@ -134,13 +138,16 @@ function activate(context) {
 								output = output.trim();
 								output = removeBackspaces(output);
 
-								console.log('output: ', output);
+								// console.log('output: ', output);
 								
 								let outputUpdated = tracker.updateOutput(output);	
 								console.log('output.txt updated?', outputUpdated);
 
 								if(outputUpdated){
-									// tracker.checkWebData();
+									tracker.checkWebData();
+								} else {
+									// if output.txt is not updated, then we should revert the git add
+									tracker.gitReset();
 								}
 
 								// console.log('globalStr of %s before reset: ', pid, allTerminalsData[pid]);
@@ -213,6 +220,14 @@ function activate(context) {
 					event.terminal.processId.then(pid => {
 						var terminalData = event.data.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
 
+						if(typeof allTerminalsData[pid] === 'undefined'){
+							allTerminalsData[pid] = "";
+						}
+
+						if(typeof allTerminalsDirCount[pid] === 'undefined'){
+							allTerminalsDirCount[pid] = 0;
+						}
+
 						// test if very_special_regex matches
 						if(very_special_regex.test(terminalData)){
 							// get the matched string
@@ -232,14 +247,6 @@ function activate(context) {
 								// add length of matched array to counterMatchedDir
 								allTerminalsDirCount[pid] += matched.length;
 							}
-						}
-
-						if(typeof allTerminalsData[pid] === 'undefined'){
-							allTerminalsData[pid] = "";
-						}
-
-						if(typeof allTerminalsDirCount[pid] === 'undefined'){
-							allTerminalsDirCount[pid] = 0;
 						}
 
 						// iter += 1;
@@ -342,6 +349,14 @@ function activate(context) {
 				if(event.terminal.name == terminalName){
 					event.terminal.processId.then(pid => {
 						var terminalData = event.data.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+
+						if(typeof allTerminalsData[pid] === 'undefined'){
+							allTerminalsData[pid] = "";
+						}
+
+						if(typeof allTerminalsDirCount[pid] === 'undefined'){
+							allTerminalsDirCount[pid] = 0;
+						}
 						
 						// test if very_special_regex matches
 						if(very_special_regex.test(terminalData)){
@@ -357,8 +372,11 @@ function activate(context) {
 							var matched = terminalData.match(linux_regex_dir);
 							// console.log('matched: ', matched);
 							
-							// add length of matched array to counterMatchedDir
-							allTerminalsDirCount[pid] += matched.length;
+							//if matched.length is a number
+							if(matched.length){
+								// add length of matched array to counterMatchedDir
+								allTerminalsDirCount[pid] += matched.length;
+							}
 						}
 
 						// iter += 1;
@@ -367,7 +385,7 @@ function activate(context) {
 
 						// allTerminalsData[pid] = globalStr of the terminal instance with pid
 						allTerminalsData[pid] += terminalData;
-						console.log('globalStr of %s: ', pid, allTerminalsData[pid]);
+						// console.log('globalStr of %s: ', pid, allTerminalsData[pid]);
 
 						// if(checkThenCommit){
 							console.log('There are %s matched regex dir for pid %s', allTerminalsDirCount[pid], pid);
@@ -398,13 +416,16 @@ function activate(context) {
 								output = output.trim();
 								output = removeBackspaces(output);
 
-								console.log('output: ', output);
+								// console.log('output: ', output);
 								
 								let outputUpdated = tracker.updateOutput(output);	
 								console.log('output.txt updated?', outputUpdated);
 
 								if(outputUpdated){
 									tracker.checkWebData();
+								} else {
+									// if output.txt is not updated, then we should revert the git add
+									tracker.gitReset();
 								}
 
 								// console.log('globalStr of %s before reset: ', pid, allTerminalsData[pid]);

--- a/src/extension.js
+++ b/src/extension.js
@@ -37,25 +37,6 @@ function activate(context) {
 	tracker = new gitTracker(currentDir);
 	tracker.createGitFolders();
 
-	// // get all existing terminal instances
-	// var terminals = vscode.window.terminals;
-
-	// // check if there are any existing terminals with the desired name
-	// var existingTerminal = terminals.find(t => t.name === 'Code Histories');
-
-	// // create a new terminal instance only if there are no existing terminals with the desired name
-	// if (!existingTerminal) {
-	// 	// create a new terminal instance with name terminalName
-	// 	var codeHistoriesTerminal = new Terminal(terminalName, currentDir);
-
-	// 	// codeHistoriesTerminal.checkBashProfilePath();
-	// 	codeHistoriesTerminal.show();
-	// 	codeHistoriesTerminal.sendText(`source ~/.bash_profile`);
-	// } else {
-	// 	existingTerminal.show();
-	// 	existingTerminal.sendText(`source ~/.bash_profile`);
-	// }
-
 	// get user and hostname for regex matching
 	var user = os.userInfo().username;
 	var hostname = os.hostname();
@@ -513,6 +494,7 @@ function activate(context) {
 				if (!existingTerminal) {
 					// create a new terminal instance with name terminalName
 					var codeHistoriesTerminal = new Terminal(terminalName, currentDir);
+					codeHistoriesTerminal.checkBashProfilePath();
 					codeHistoriesTerminal.show();
 					codeHistoriesTerminal.sendText(cmdPrompt);
 				} else {
@@ -550,14 +532,10 @@ function activate(context) {
 	context.subscriptions.push(setNewCmd);
 }
 
-function countOccurrences(string, word) {
-	return string.split(word).length - 1;
-}
-
 function removeBackspaces(str) {
 	var pattern = /[\u0000]|[\u0001]|[\u0002]|[\u0003]|[\u0004]|[\u0005]|[\u0006]|[\u0007]|[\u0008]|[\u000b]|[\u000c]|[\u000d]|[\u000e]|[\u000f]|[\u0010]|[\u0011]|[\u0012]|[\u0013]|[\u0014]|[\u0015]|[\u0016]|[\u0017]|[\u0018]|[\u0019]|[\u001a]|[\u001b]|[\u001c]|[\u001d]|[\u001e]|[\u001f]|[\u001c]|[\u007f]|[\u0040]/gm;
-    while (str.indexOf("\u0008") != -1) {
-        str = str.replace(/.?\u0008/, ""); // 0x08 is the ASCII code for \b
+    while (str.indexOf("\b") != -1) {
+        str = str.replace(/.?\x08/, ""); // 0x08 is the ASCII code for \b
     }
 	str = str.replace(pattern, "");	
 	return str;

--- a/src/extension.js
+++ b/src/extension.js
@@ -32,7 +32,7 @@ function activate(context) {
 	}
 
 	// check git init status
-	simpleGit().clean(simpleGit.CleanOptions.FORCE);
+	// simpleGit().clean(simpleGit.CleanOptions.FORCE);
 	var currentDir = vscode.workspace.workspaceFolders[0].uri.fsPath;
 	tracker = new gitTracker(currentDir);
 	tracker.createGitFolders();
@@ -513,7 +513,7 @@ function activate(context) {
 					var codeHistoriesTerminal = new Terminal(terminalName, currentDir);
 					codeHistoriesTerminal.checkBashProfilePath();
 					codeHistoriesTerminal.show();
-					codeHistoriesTerminal.sendText(cmdPrompt);
+					codeHistoriesTerminal.sendText(`source ~/.bash_profile`);
 				} else {
 					existingTerminal.show();
 					existingTerminal.sendText(cmdPrompt);

--- a/src/extension.js
+++ b/src/extension.js
@@ -248,7 +248,7 @@ function activate(context) {
 
 						// allTerminalsData[pid] = globalStr of the terminal instance with pid
 						allTerminalsData[pid] += terminalData;
-						console.log('allTerminalsData: ', pid, allTerminalsData[pid]);
+						// console.log('allTerminalsData: ', pid, allTerminalsData[pid]);
 
 						// if(checkThenCommit){
 							console.log('There are %s matched regex dir for pid %s', allTerminalsDirCount[pid], pid);
@@ -279,13 +279,16 @@ function activate(context) {
 								output = output.trim();
 								output = removeBackspaces(output);
 						
-								console.log('output: ', output);
+								// console.log('output: ', output);
 								
 								let outputUpdated = tracker.updateOutput(output);	
 								console.log('output.txt updated?', outputUpdated);
 
 								if(outputUpdated){
-									// tracker.checkWebData();
+									tracker.checkWebData();
+								} else {
+									// if output.txt is not updated, then we should revert the git add
+									tracker.gitReset();
 								}
 
 								// console.log('globalStr of %s before reset: ', pid, allTerminalsData[pid]);

--- a/src/extension.js
+++ b/src/extension.js
@@ -484,14 +484,8 @@ function activate(context) {
 			"terminal.integrated.defaultProfile.windows": "Git Bash",
 			"terminal.integrated.defaultProfile.osx": "bash",
 			"terminal.integrated.defaultProfile.linux": "bash",
-			"code-runner.runInTerminal": true,
-			"code-runner.ignoreSelection": true,
-			"code-runner.clearPreviousOutput": false,
 			"terminal.integrated.shellIntegration.enabled": false,
-			"python.terminal.activateEnvironment": false,
-			"code-runner.executorMap": {
-				"html": "python -m http.server 8080 --directory \"$workspaceRoot\"",
-			}
+			"python.terminal.activateEnvironment": false
 		}, null, 4);
 
 		if(!fs.existsSync(vscodePath)){
@@ -506,11 +500,7 @@ function activate(context) {
 			// add all files to git
 			tracker.gitAdd();
 
-			if(terminalName == "Python"){
-				vscode.commands.executeCommand('python.execInTerminal');
-			} else if(terminalName == "Code"){
-				vscode.commands.executeCommand('code-runner.run');
-			} else if(terminalName == "Code Histories"){
+			if(terminalName == "Code Histories"){
 				// get all existing terminal instances
 				var terminals = vscode.window.terminals;
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -325,7 +325,7 @@ function activate(context) {
 
 	}
 
-	/*if(process.platform === 'linux'){
+	if(process.platform === 'linux'){
 		// linux defaut bash e.g. tri@tri-VirtualBox:~/Desktop/test$
 		var linux_regex_dir = new RegExp("(\(.*\))?" + user + "@" + hostname + ".*\\${1}", "g");
 		
@@ -364,8 +364,9 @@ function activate(context) {
 
 						// allTerminalsData[pid] = globalStr of the terminal instance with pid
 						allTerminalsData[pid] += terminalData;
+						console.log('globalStr of %s: ', pid, allTerminalsData[pid]);
 
-						if(checkThenCommit){
+						// if(checkThenCommit){
 							console.log('There are %s matched regex dir for pid %s', allTerminalsDirCount[pid], pid);
 
 							// if counter is >= 2, then we should have enough information to trim and find the output
@@ -385,14 +386,16 @@ function activate(context) {
 								let lastOccurence = allTerminalsData[pid].lastIndexOf(matched[matched.length - 1]);
 
 								// find the first occurrence of "\r\n" after the second to last occurence of linux_regex_dir
-								let firstOccurenceOfNewLine = allTerminalsData[pid].indexOf("\r\n", secondToLastOccurence);
+								// let firstOccurenceOfNewLine = allTerminalsData[pid].indexOf("\r\n", secondToLastOccurence);
 
-								let output = allTerminalsData[pid].substring(firstOccurenceOfNewLine, lastOccurence);
+								let output = allTerminalsData[pid].substring(secondToLastOccurence, lastOccurence);
 
 								// clear residual \033]0; and \007 (ESC]0; and BEL)
 								output = output.replace(/\\033]0; | \\007/g, "");
 								output = output.trim();
 								output = removeBackspaces(output);
+
+								console.log('output: ', output);
 								
 								let outputUpdated = tracker.updateOutput(output);	
 								console.log('output.txt updated?', outputUpdated);
@@ -410,7 +413,7 @@ function activate(context) {
 								allTerminalsDirCount[pid] = 1;
 								checkThenCommit = false;
 							}
-						}
+						// }
 					});
 				}
 			}
@@ -435,7 +438,7 @@ function activate(context) {
 				});
 			}
 		});
-	} */
+	}
 
 	let disposable = vscode.commands.registerCommand('codeHistories.codeHistories', function () {
 		vscode.window.showInformationMessage('Code histories activated!');

--- a/src/git-tracker.js
+++ b/src/git-tracker.js
@@ -174,6 +174,9 @@ module.exports = class gitTracker {
                 this.git.log((err, log) => {
                     if(err) {
                         console.log(err);
+                        // create codeHistories.git
+                        this.codeHistoriesGit = simpleGit(this._currentDir).env({ 'GIT_DIR': this._currentDir + '/codeHistories.git' , 'GIT_WORK_TREE': this._currentDir });
+                        this.initializeGit(this.codeHistoriesGit);
                     }
                     else {
                         if(log.total == 0) {
@@ -329,11 +332,17 @@ module.exports = class gitTracker {
 
     checkEdgeCases(str){
         // console.log(str);
-        let edgeCasesRegex = /(clear|gitk)[\s]*|(pwd|ls|cd|mkdir|touch|cp|rm|nano|cat|echo|apt|pip|git)[\s]+/g;
-        if(edgeCasesRegex.test(str)){
-            console.log("Encounter edge case", str.match(edgeCasesRegex));
-            return false;
+        // let edgeCasesRegex = /(clear|gitk)[\s]*|(pwd|ls|cd|mkdir|touch|cp|rm|nano|cat|echo|apt|pip|git)[\s]+/g;
+        // if(edgeCasesRegex.test(str)){
+        //     console.log("Encounter edge case", str.match(edgeCasesRegex));
+        //     return false;
+        // }
+        // return true;
+
+        // only returns true if str contains codehistories
+        if(str.includes("codehistories")){
+            return true;
         }
-        return true;
+        return false;
     }
 }

--- a/src/git-tracker.js
+++ b/src/git-tracker.js
@@ -206,11 +206,6 @@ module.exports = class gitTracker {
 
                             // copy .git to codeHistories.git
                             fs.cpSync(this._currentDir + '/.git', this._currentDir + '/codeHistories.git', {recursive: true});
-
-                            // remove all commits that have [Commit time:.*] in the commit message
-                            // for(var i = 0; i < hashes.length; i++) {
-                            //     this.git.reset(['--soft', hashes[i]]);
-                            // }
                         }
                     }
                 });
@@ -230,9 +225,45 @@ module.exports = class gitTracker {
         // this happens as soon as the user clicks on the checkAndCommit button
         // to avoid situation where user maybe changing files while committing (the commit will be based on the files at the time of clicking the button)
         if(this.isUsingCodeHistoriesGit) {
-            this.codeHistoriesGit.add('./*');
+            let addCmd = `git --git-dir=${this._currentDir}/codeHistories.git --work-tree=${this._currentDir} add .`;
+            cp.exec(addCmd, {cwd: this._currentDir}, (err, stdout, stderr) => {
+                if(err) {
+                    console.log('Error adding all files to codeHistories.git');
+                    console.log(err);
+                    return;
+                }
+                console.log('Added all files to codeHistories.git');
+            });
         } else {
-            this.git.add('./*');
+            this.git.add('./*').then((success) => {
+                console.log('Added all files to .git');
+            }, (err) => {
+                console.log('Error adding all files to .git');
+                console.log(err);
+            });
+        }
+    }
+
+    gitReset(){
+        // reset all files
+        // this happens as soon as output.txt not updated
+        if(this.isUsingCodeHistoriesGit) {
+            let resetCmd = `git --git-dir=${this._currentDir}/codeHistories.git --work-tree=${this._currentDir} reset`;
+            cp.exec(resetCmd, {cwd: this._currentDir}, (err, stdout, stderr) => {
+                if(err) {
+                    console.log('Error resetting all files in codeHistories.git');
+                    console.log(err);
+                    return;
+                }
+                console.log('Successfully reset all files in codeHistories.git');
+            });
+        } else {
+            this.git.reset(['./*']).then((success) => {
+                console.log('Successfully reset all files in .git');
+            }, (err) => {
+                console.log('Error resetting all files in .git');
+                console.log(err);
+            });
         }
     }
 
@@ -242,29 +273,25 @@ module.exports = class gitTracker {
         var conversion = new Date(timeStamp).toLocaleString('en-US');
         var commitMessage = `[Commit time: ${conversion}]`;
         if(this.isUsingCodeHistoriesGit) {
-            if(process.platform == 'linux') {
-                // use cp.exec to run git commit
-                let commitCmd = 'git ' + '--git-dir=' + this._currentDir + '/codeHistories.git' + ' --work-tree=' + this._currentDir + ' commit -m "' + commitMessage + '"';
-                cp.exec(commitCmd, {cwd: this._currentDir}, (error, stdout, stderr) => {
-                    if (error) {
-                        console.error(`exec error: ${error}`);
-                        return;
-                    }
-                });
-            } else {
-                // use simple-git to run git commit
-                this.codeHistoriesGit.commit(commitMessage).then((success) => {
-                    console.log("commit for codeHistories.git");
-                }, (err) => {
-                    console.log(err);
+            let commitCmd = `git --git-dir=${this._currentDir}/codeHistories.git --work-tree=${this._currentDir} commit -m "${commitMessage}"`;
+            cp.exec(commitCmd, {cwd: this._currentDir}, (error, stdout, stderr) => {
+                if (error) {
+                    console.error(`exec error: ${error}`);
                     vscode.window.showErrorMessage('Commit failed! Please try again.');
-                });
-            }
+                    return;
+                }
+                console.log('Committed to codeHistories.git');
+                this.keepOrUndoCommit();
+            });
         } else {
-            this.git.commit(commitMessage);
-            console.log("commit for .git");
+            this.git.commit(commitMessage).then((success) => {
+                console.log('Committed to .git');
+                this.keepOrUndoCommit();
+            }, (err) => {
+                console.log(err);
+                vscode.window.showErrorMessage('Commit failed! Please try again.');
+            });
         }
-        this.keepOrUndoCommit();
     }
 
     checkWebData(){
@@ -286,9 +313,22 @@ module.exports = class gitTracker {
             });
         }).then(() => {
             if(this.isUsingCodeHistoriesGit) {
-                this.codeHistoriesGit.add('webData');
+                let addWebDataCmd = `git --git-dir=${this._currentDir}/codeHistories.git --work-tree=${this._currentDir} add webData`;
+                cp.exec(addWebDataCmd, {cwd: this._currentDir}, (err, stdout, stderr) => {
+                    if(err) {
+                        console.log('Error adding webData to codeHistories.git');
+                        console.log(err);
+                        return;
+                    }
+                    console.log('Added webData to codeHistories.git');
+                });
             } else {
-                this.git.add('webData');
+                this.git.add('webData').then((success) => {
+                    console.log('Added webData to .git');
+                }, (err) => {
+                    console.log('Error adding webData to .git');
+                    console.log(err);
+                });
             }
             this.gitCommit();
         }); 
@@ -301,16 +341,31 @@ module.exports = class gitTracker {
         }
         else if (choice === 'Undo commit') {
             if(this.isUsingCodeHistoriesGit) {
-                console.log("undoing commit for codeHistories.git");
-                this.codeHistoriesGit.reset(['HEAD~1']);
+                let undoCmd = `git --git-dir=${this._currentDir}/codeHistories.git --work-tree=${this._currentDir} reset HEAD~1`;
+                cp.exec(undoCmd, {cwd: this._currentDir}, (err, stdout, stderr) => {
+                    if(err) {
+                        console.log('Error undoing last commit for codeHistories.git');
+                        console.log(err);
+                        return;
+                    }
+                    console.log('Successfully undone commit for codeHistories.git');
+                });
             } else {
                 console.log("undoing commit for .git");
-                this.git.reset(['HEAD~1']);
+                this.git.reset(['HEAD~1']).then((success) => {
+                    console.log("Successfully undone commit for .git");
+                }, (err) => {
+                    console.log('Error undoing commit for .git');
+                    console.log(err);
+                });
             }
         }
     }
 
     updateOutput(output){
+        // stage everything before updating output.txt
+        this.gitAdd();
+
         // store output of current terminal to a new file
         // if file already exists, append to it
         if(!this.checkEdgeCases(output)){
@@ -350,9 +405,22 @@ module.exports = class gitTracker {
         }
 
         if(this.isUsingCodeHistoriesGit) {
-            this.codeHistoriesGit.add('output.txt');
+            let addOutputCmd = `git --git-dir=${this._currentDir}/codeHistories.git --work-tree=${this._currentDir} add output.txt`;
+            cp.exec(addOutputCmd, {cwd: this._currentDir}, (err, stdout, stderr) => {
+                if(err) {
+                    console.log('Error adding output.txt to codeHistories.git');
+                    console.log(err);
+                    return;
+                }
+                console.log('Added output.txt to codeHistories.git');
+            });
         } else {
-            this.git.add('output.txt');
+            this.git.add('output.txt').then((success) => {
+                console.log('Added output.txt to .git');
+            }, (err) => {
+                console.log('Error adding output.txt to .git');
+                console.log(err);
+            });
         }
         return true;
     }

--- a/src/git-tracker.js
+++ b/src/git-tracker.js
@@ -340,9 +340,13 @@ module.exports = class gitTracker {
         // return true;
 
         // only returns true if str contains codehistories
-        if(str.includes("codehistories")){
+        if(str.includes("codehistories") && this.countOccurrences(str, "codehistories") == 1){
             return true;
         }
         return false;
+    }
+
+    countOccurrences(string, word) {
+        return string.split(word).length - 1;
     }
 }

--- a/src/terminal.js
+++ b/src/terminal.js
@@ -1,6 +1,7 @@
 const vscode = require('vscode');
 const os = require('os');
 const fs = require('fs');
+const path = require('path');
 
 class Terminal {
   constructor(name, cwd) {
@@ -13,6 +14,11 @@ class Terminal {
       shellPath: this.terminalShellPath,
       shellArgs: [],
     });
+
+    let promptCommand = this.getPromptCommand();
+    if (promptCommand) {
+      this.terminal.sendText(promptCommand);
+    }
   }
 
   show() {
@@ -21,6 +27,19 @@ class Terminal {
 
   sendText(text) {
     this.terminal.sendText(text);
+  }
+
+  getPromptCommand() {
+    let promptCommand = '';
+    if (os.platform() === 'darwin') {
+      this.terminalShellPath = '/bin/bash';
+
+      // when open up a new terminal, bash-3.2$ was shown
+      // change this to hostname:current_directory username$
+      promptCommand = "export PS1='\\h:\\W \\u\\$ '";
+    }
+
+    return promptCommand;
   }
 
   checkBashProfilePath(){

--- a/src/terminal.js
+++ b/src/terminal.js
@@ -1,0 +1,51 @@
+const vscode = require('vscode');
+const os = require('os');
+const fs = require('fs');
+
+class Terminal {
+  constructor(name, cwd) {
+    this.name = name;
+    this.cwd = cwd;
+    this.terminalShellPath = os.platform() === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.exe' : '/bin/bash';
+    this.terminal = vscode.window.createTerminal({
+      name: this.name,
+      cwd: this.cwd,
+      shellPath: this.terminalShellPath,
+      shellArgs: [],
+    });
+  }
+
+  show() {
+    this.terminal.show();
+  }
+
+  sendText(text) {
+    this.terminal.sendText(text);
+  }
+
+  checkBashProfilePath(){
+    const bashProfilePath = `${os.homedir()}/.bash_profile`;
+    const content = `
+codehistories() {
+  if [ "$#" -eq 0 ]; then
+    echo "Usage: codehistories <command> [args]"
+    return
+  fi
+  cmd="$1"
+  shift
+  eval "$cmd" "$@"
+}`;
+    if (!fs.existsSync(bashProfilePath)) {
+      // create the file and add these lines
+      fs.writeFileSync(bashProfilePath, content);
+    } else {
+      // check if the lines are already there
+      const fileContent = fs.readFileSync(bashProfilePath, 'utf8');
+      if (!fileContent.includes('codehistories')) {
+        fs.appendFileSync(bashProfilePath, content);
+      }
+    }
+  }
+}
+
+module.exports = Terminal;

--- a/src/terminal.js
+++ b/src/terminal.js
@@ -32,8 +32,6 @@ class Terminal {
   getPromptCommand() {
     let promptCommand = '';
     if (os.platform() === 'darwin') {
-      this.terminalShellPath = '/bin/bash';
-
       // when open up a new terminal, bash-3.2$ was shown
       // change this to hostname:current_directory username$
       promptCommand = "export PS1='\\h:\\W \\u\\$ '";
@@ -57,11 +55,13 @@ codehistories() {
     if (!fs.existsSync(bashProfilePath)) {
       // create the file and add these lines
       fs.writeFileSync(bashProfilePath, content);
+      console.log('Created .bash_profile and added codehistories.');
     } else {
       // check if the lines are already there
       const fileContent = fs.readFileSync(bashProfilePath, 'utf8');
-      if (!fileContent.includes('codehistories')) {
+      if (!fileContent.includes('codehistories()')) {
         fs.appendFileSync(bashProfilePath, content);
+        console.log('Added codehistories to .bash_profile.');
       }
     }
   }


### PR DESCRIPTION
Remove the need for code runner extension and allow user more flexibility in running commands of their choice. However, they must have "codehistories" as prefix so the tool can match and trigger the capture. User can set a fix command for subsequent executions using CMD+SHIFT+C (or CTRL+SHIFT+C on Windows). A setup demo video added also touches on the features and discusses the workflow.